### PR TITLE
Actualizar enlaces del README.es.md, diseño y división

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -9,7 +9,7 @@ Cada alumno trabajará en un archivo diferente para cada parte diferente del sit
 
 1. El líder del equipo debe hacerle fork a este repositorio de github.com e [invitar a otros colaboradores a ese repositorio](https://github.com/breatheco-de/exercise-git-collabration/blob/master/iOBmU5zYqA.gif).
 
-2. Vamos a realizar [este diseño](https://raw.githubusercontent.com/breatheco-de/exercise-collaborative-html-website/master/website1/designs/thumb.jpg), y [de esta forma pueden dividirlo entre los estudiantes](https://github.com/breatheco-de/exercise-collaborative-html-website/blob/master/website1/designs/guide.jpg?raw=true).
+2. Vamos a realizar [este diseño](https://raw.githubusercontent.com/breatheco-de/exercise-collaborative-html-website/master/website/designs/thumb.jpg), y [de esta forma pueden dividirlo entre los estudiantes](https://raw.githubusercontent.com/breatheco-de/exercise-collaborative-html-website/master/website/designs/guide.jpg).
 
 3. Cada colaborador tendrá que clonar el nuevo repositorio forkeado por el líder de equipo y desarrollar una parte del sitio web escogido, cada proyecto está dividido en partes dentro del directorio `website/templates/`. Cuando todos tengan su editor de código abierto, pueden iniciar el proyecto con este comando:
 


### PR DESCRIPTION
Actualizamos  los enlaces al diseño y la división en el readme.es.md para que estos nos lleven a las imágenes correctas, en la versión actual no enlazan a ninguna imagen.